### PR TITLE
Accept hash parameter of getTransactions in base64 as well as in hex.

### DIFF
--- a/pyTON/main.py
+++ b/pyTON/main.py
@@ -290,7 +290,7 @@ async def get_transactions(
     address: str = Query(..., description="Identifier of target TON account in any form."), 
     limit: Optional[int] = Query(default=10, description="Maximum number of transactions in response."), 
     lt: Optional[int] = Query(default=None, description="Logical time of transaction to start with, must be sent with *hash*."), 
-    hash: Optional[str] = Query(default=None, description="Hash of transaction to start with, in **base64 encoding** , must be sent with *lt*."), 
+    hash: Optional[str] = Query(default=None, description="Hash of transaction to start with, in *base64* or *hex* encoding , must be sent with *lt*."), 
     to_lt: Optional[int] = Query(default=0, description="Logical time of transaction to finish with (to get tx from *lt* to *to_lt*)."), 
     archival: bool = Query(default=False, description="By default getTransaction request is processed by any available liteserver. If *archival=true* only liteservers with full history are used.")
     ):

--- a/pyTON/utils.py
+++ b/pyTON/utils.py
@@ -6,6 +6,7 @@ import asyncio
 import struct
 import json
 import crc16
+import codecs
 
 
 class TonLibWrongResult(Exception):
@@ -16,6 +17,29 @@ class TonLibWrongResult(Exception):
     def __str__(self):
         return f"{self.description} - unexpected lite server response:\n\t{json.dumps(self.result)}"
 
+def b64str_to_bytes(b64str):
+    b64bytes = codecs.encode(b64str, "utf8")
+    return codecs.decode(b64bytes, "base64")
+
+def b64str_to_hex(b64str):
+    _bytes = b64str_to_bytes(b64str)
+    _hex = codecs.encode(_bytes, "hex")
+    return codecs.decode(_hex, "utf8")
+
+def hex_to_b64str(x):
+    return codecs.encode(codecs.decode(x, 'hex'), 'base64').decode().replace("\n", "")
+
+def hash_to_hex(b64_or_hex_hash):
+    """
+    Detect encoding of transactions hash and if necessary convert it to hex.
+    """
+    if len(b64_or_hex_hash) == 44:
+        # Hash is base64
+        return b64str_to_hex(b64_or_hex_hash)
+    if len(b64_or_hex_hash) == 64:
+        # Hash is hex
+        return b64_or_hex_hash
+    raise ValueError("Invalid hash")
 
 def pubkey_b64_to_hex(b64_key):
     """


### PR DESCRIPTION
Detect hash encoding based on the length and convert to hex if base64 is received. Converting to hex is required since tonlib accepts only hex hashes.
Fixes issue #7 