### PR TITLE
Update Ubuntu version from 20.04 to 22.04

### DIFF
--- a/ton-http-api/.docker/Dockerfile
+++ b/ton-http-api/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata


### PR DESCRIPTION
Hi team,

I have updated the Ubuntu version in the Docker image from 20.04 to 22.04. This update includes important security fixes and feature enhancements. Here are the key changes made in this pull request:

1. Upgraded Ubuntu base image from 20.04 to 22.04.
2. Resolved 404 errors encountered while fetching certain packages during the update process.
3. Verified compatibility with existing software and dependencies.

Please review and test the changes. Once approved, we can proceed with merging this pull request and updating our Docker images.

Thank you.
Dr.Awesome Doge