### PR TITLE
Actually, the shard of the TON workchain should be string, other than int

### DIFF
--- a/ton-http-api/pyTON/main.py
+++ b/ton-http-api/pyTON/main.py
@@ -435,7 +435,7 @@ async def shards(
 @wrap_result
 async def get_block_transactions(
     workchain: int, 
-    shard: int, 
+    shard: str, 
     seqno: int, 
     root_hash: Optional[str] = None, 
     file_hash: Optional[str] = None, 


### PR DESCRIPTION
Plz help to review the change.

The shard of workchain should be string, such as 
```
      "workchain": 0,
      "shard": "C800000000000000",
      "seqno": 45986773,
```