### PR TITLE
Added CORS

### DIFF
--- a/ton-http-api/pyTON/main.py
+++ b/ton-http-api/pyTON/main.py
@@ -16,6 +16,7 @@ from typing import Optional, Union, Dict, Any, List
 from fastapi import FastAPI, Depends, Response, Request, BackgroundTasks
 from fastapi.params import Body, Query, Param
 from fastapi.exceptions import HTTPException, RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from fastapi.responses import JSONResponse
 from fastapi import status
@@ -111,6 +112,14 @@ app = FastAPI(
     },
     root_path=settings.webserver.api_root_path,
     openapi_tags=tags_metadata
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_credentials=True,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 


### PR DESCRIPTION
I had issues when running the following code in the browser:

```
import { Address, beginCell, toNano } from '@ton/core';
import { TonClient } from '@ton/ton';

const client = new TonClient({ endpoint: 'http://localhost:8082/jsonRPC' });

const contractAddress = Address.parse('0:1da77f0269bbbb76c862ea424b257df63bd1acb0d4eb681b68c9aadfbf553b93');

const totalBalance = Number(await client.getBalance(contractAddress)) / 1e9;
```

When `await client.getBalance()` was throwing a CORS error in the browser.

So I added CORS support to the FastAPI server.